### PR TITLE
Add GroupMemberInfo

### DIFF
--- a/cqsocketapi/APIClient.cpp
+++ b/cqsocketapi/APIClient.cpp
@@ -82,3 +82,12 @@ void APIClient::send(const char *buffer, const int len)
 		sendto(sock, buffer, len, 0, (sockaddr *)&clients[i].info, sizeof(clients[i].info));
 	}
 }
+
+void APIClient::send(const char *buffer, const int len, int port)
+{
+	for (int i = 0; i < CLIENT_SIZE; i++) {
+		if (clients[i].port == port) {
+			sendto(sock, buffer, len, 0, (sockaddr *)&clients[i].info, sizeof(clients[i].info));
+		}
+	}
+}

--- a/cqsocketapi/APIClient.h
+++ b/cqsocketapi/APIClient.h
@@ -17,6 +17,7 @@ public:
 	~APIClient(void);
 	void add(const int port);
 	void send(const char *buffer, const int len);
+	void send(const char *buffer, const int len, int port);
 private:
 	SOCKET sock;
 	struct APIClientInfo* clients;

--- a/cqsocketapi/APIServer.cpp
+++ b/cqsocketapi/APIServer.cpp
@@ -57,6 +57,18 @@ void prcsDiscussMessage(const char *payload) {
 	CQ_sendDiscussMsg(appAuthCode, id, decodedText);
 }
 
+void prcsGroupMemberInfo(const char *payload) {
+	int64_t port; int64_t groupId; int64_t id;
+	sscanf_s(payload, "%I64d %I64d %I64d", &port, &groupId, &id, sizeof(char) * FRAME_PAYLOAD_SIZE);
+
+	const char* buffer = CQ_getGroupMemberInfoV2(appAuthCode, groupId, id, false);
+	if (strlen(buffer) == 0) {
+		buffer = "-1";
+	}
+
+	client->send(buffer, strlen(buffer), port);
+}
+
 void prcsUnknownFramePrefix(const char *buffer) {
 	char category[] = "UnknownFramePrefix";
 	CQ_addLog(appAuthCode, CQLOG_WARNING, category, buffer);
@@ -115,6 +127,11 @@ void APIServer::run()
 				prcsDiscussMessage(payload);
 				continue;
 			}
+			if (strcmp(prefix, "GroupMemberInfo") == 0) {
+				prcsGroupMemberInfo(payload);
+				continue;
+			}
+			
 			// Unknown prefix
 			prcsUnknownFramePrefix(buffer);
 		}


### PR DESCRIPTION
Add method to get user information in group. Format: GroupMemberInfo
<ClientPort> <Group> <User>. Return -1 if failed(user isn't in the
group) , otherwise return a Base64 encoded message .
