### PR TITLE
README: Tell people to use GB 18030, fix #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Payload = GroupID + QQ + OperatedQQ
 Prefix = 'GroupMemberIncrease'
 Payload = GroupID + QQ + OperatedQQ
 
-EncodedText = base64_encode( GBK_encode( text ) )
+EncodedText = base64_encode( GB18030_encode( text ) )
 ```
 
 ### Client Sent Frame
@@ -63,7 +63,7 @@ Payload = GroupID + EncodedText
 Prefix = 'DiscussMessage'
 Payload = DiscussID + EncodedText
 
-EncodedText = base64_encode( GBK_encode( text ) )
+EncodedText = base64_encode( GB18030_encode( text ) )
 ```
 
 ### Example Frame


### PR DESCRIPTION
Character U+34B2 (㒲):
GBK: (not defined)
GB18030: 82 30 82 35 ("UTF" area)
Decode GB18030 as GBK: U+FFFD U+0030 U+FFFD U+0035
Decode GB18030 as GB18030: U+34B2